### PR TITLE
Add compatibility with EDD 3.0

### DIFF
--- a/includes/admin-actions.php
+++ b/includes/admin-actions.php
@@ -21,10 +21,19 @@ function edd_import_process_coupon_file() {
 	$edd_message = '';
 
 	if ( isset( $_POST['edd-action'] ) && ( $_POST['edd-action'] == 'import_coupon_csv' ) ) {
+		// Bail if no nonce or nonce fails.
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( $_POST['_wpnonce'], 'edd_generate_mapping' ) ) {
+			return;
+		}
+
+		// Bail if current user cannot manage shop discounts.
+		if ( ! current_user_can( 'manage_shop_discounts' ) ) {
+			return;
+		}
 
 		// check for file
 
-		if ( empty( $_FILES ) || $_FILES['import_file']['size'] == 0 ){
+		if ( empty( $_FILES ) || ! isset( $_FILES['import_file']['size'] ) || $_FILES['import_file']['size'] == 0 ) {
 			$edd_message = 'Please choose a file to import.';
 			return;
 		}

--- a/includes/admin-page.php
+++ b/includes/admin-page.php
@@ -21,7 +21,7 @@
 
 function edd_csv_coupon_import_menu() {
 	global $edd_csv_coupon_import_page;
-		$edd_csv_coupon_import_page = add_submenu_page( 'edit.php?post_type=download', __('Easy Digital Download CSV Coupon Import', 'edd'), __('Import Coupons', 'edd'), 'manage_options', 'edd-csv-coupon-import', 'edd_csv_coupon_import_page' );
+		$edd_csv_coupon_import_page = add_submenu_page( 'edit.php?post_type=download', __('Easy Digital Download CSV Coupon Import', 'edd'), __('Import Coupons', 'edd'), 'manage_shop_discounts', 'edd-csv-coupon-import', 'edd_csv_coupon_import_page' );
 }
 add_action( 'admin_menu', 'edd_csv_coupon_import_menu', 10 );
 

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -189,6 +189,13 @@ function edd_import_coupon_csv_file() {
 						$validation_msg  .= __('Status needs to be active, inactive, or pending', 'edd') . "; ";
 					}
 
+					// Check product condition.
+					$product_conditions = array( 'all', 'any' );
+					if ( ! in_array( $edd_discount_product_condition, $product_conditions ) ) {
+						$validation_error = true;
+						$validation_msg  .= __('Product condition is invalid.', 'edd') . "; ";
+					}
+
 					// maybe more validation later
 
 					if ( $validation_error ) {

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -153,7 +153,7 @@ function edd_import_coupon_csv_file() {
 
 					// discount type is invalid
 					$discount_types = array( 'flat', 'percentage' );
-					if ( ! in_array( $edd_discount_type, $discount_types ) ) {
+					if ( ! in_array( $edd_discount_type, $discount_types, true ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Discount type is invalid.', 'edd') . "; ";
 					}
@@ -191,7 +191,7 @@ function edd_import_coupon_csv_file() {
 
 					// Check product condition.
 					$product_conditions = array( 'all', 'any' );
-					if ( ! in_array( $edd_discount_product_condition, $product_conditions ) ) {
+					if ( ! in_array( $edd_discount_product_condition, $product_conditions, true ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Product condition is invalid.', 'edd') . "; ";
 					}

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -45,7 +45,7 @@ function edd_show_coupon_upload_form() {
 			</tr>
 			<tr valign="top">
 				<th scope="row"><?php _e('Validate File Only','edd') ?></th>
-				<td><input type="checkbox" id="check_file" name="check_file" value="on" /> <?php _e('Check file, but do not save coupons to the database.','edd') ?></td>
+				<td><label for="check_file"><input type="checkbox" id="check_file" name="check_file" value="on" /> <?php esc_html_e( 'Check file, but do not save coupons to the database.', 'edd' ); ?></label></td>
 			</tr>
 		</tbody>
 		</table>

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -45,7 +45,7 @@ function edd_show_coupon_upload_form() {
 			</tr>
 			<tr valign="top">
 				<th scope="row"><?php _e('Validate File Only','edd') ?></th>
-				<td><input type="checkbox" id="check_file" name="check_file" /> <?php _e('Check file, but do not save coupons to the database.','edd') ?></td>
+				<td><input type="checkbox" id="check_file" name="check_file" value="on" /> <?php _e('Check file, but do not save coupons to the database.','edd') ?></td>
 			</tr>
 		</tbody>
 		</table>
@@ -67,7 +67,7 @@ function edd_show_coupon_upload_form() {
  * Show Import Log
  *
  * @access      public
- * @param 		edd_log_file - The log file to display
+ * @global      string $edd_log_file The log file to display
  * @since       1.0
  * @return      void
 */
@@ -109,20 +109,19 @@ function edd_import_coupon_csv_file() {
 					$edd_discount_name				= isset( $edd_options['edd_import_discount_name'] ) 			 ? $line[ $edd_options['edd_import_discount_name'] ]         : $line[0];
 					$edd_discount_code				= isset( $edd_options['edd_import_discount_code'] ) 			 ? $line[ $edd_options['edd_import_discount_code'] ]         : $line[1];
 					$edd_discount_type				= isset( $edd_options['edd_import_discount_type'] ) 			 ? $line[ $edd_options['edd_import_discount_type'] ]         : $line[2];
-					$edd_discount_start				= isset( $edd_options['edd_import_discount_start'] ) 			 ? $line[ $edd_options['edd_import_discount_start'] ]        : $line[3];					
+					$edd_discount_start				= isset( $edd_options['edd_import_discount_start'] ) 			 ? $line[ $edd_options['edd_import_discount_start'] ]        : $line[3];
 					$edd_discount_end				= isset( $edd_options['edd_import_discount_end'] ) 				 ? $line[ $edd_options['edd_import_discount_end'] ]          : $line[4];
 					$edd_discount_status			= isset( $edd_options['edd_import_discount_status'] ) 			 ? $line[ $edd_options['edd_import_discount_status'] ]       : $line[5];
 					$edd_discount_uses				= isset( $edd_options['edd_import_discount_uses'] ) 			 ? $line[ $edd_options['edd_import_discount_uses'] ]     	 : $line[6];
 					$edd_discount_max_uses			= isset( $edd_options['edd_import_discount_max_uses'] ) 		 ? $line[ $edd_options['edd_import_discount_max_uses'] ]     : $line[7];
 					$edd_discount_amount			= isset( $edd_options['edd_import_discount_amount'] ) 			 ? $line[ $edd_options['edd_import_discount_amount'] ] 		 : $line[8];
 					$edd_discount_min_price			= isset( $edd_options['edd_import_discount_min_price']) 		 ? $line[ $edd_options['edd_import_discount_min_price'] ]    : $line[9];
-					$edd_discount_product_reqs		= isset( $edd_options['edd_import_discount_product_reqs']) 		 ? $line[ $edd_options['edd_import_discount_product_reqs'] ]    : $line[10];		
+					$edd_discount_product_reqs		= isset( $edd_options['edd_import_discount_product_reqs']) 		 ? $line[ $edd_options['edd_import_discount_product_reqs'] ]    : $line[10];
 					$edd_discount_product_condition	= isset( $edd_options['edd_import_discount_product_condition'])  ? $line[ $edd_options['edd_import_discount_product_condition'] ]    : $line[11];
 					$edd_discount_is_not_global		= isset( $edd_options['edd_import_discount_is_not_global']) 	 ? $line[ $edd_options['edd_import_discount_is_not_global'] ]    : $line[12];
 					$edd_discount_is_single_use		= isset( $edd_options['edd_import_discount_is_single_use']) 	 ? $line[ $edd_options['edd_import_discount_is_single_use'] ]    : $line[13];
 					$edd_discount_id				= isset( $edd_options['edd_import_discount_id']) 				 ? $line[ $edd_options['edd_import_discount_id'] ]    : $line[14];
 
-					
 					// check for valid data
 					$validation_error = false;
 					$validation_msg  = '';
@@ -132,58 +131,65 @@ function edd_import_coupon_csv_file() {
 						$validation_error = true;
 						$validation_msg  .= __('Discount Name is blank.', 'edd') . "; ";
 					}
-					
+
 					// discount code  blank
 					if ( 0 == strlen( $edd_discount_code ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Discount code is blank.', 'edd') . "; ";
 					}
-					
+
+					// Verify only accepted characters.
+					$sanitized_discount_code = preg_replace( '/[^a-zA-Z0-9-_]+/', '', $edd_discount_code );
+					if ( strtoupper( $edd_discount_code ) !== strtoupper( $sanitized_discount_code ) ) {
+						$validation_error = true;
+						$validation_msg  .= __('Discount code is invalid.', 'edd') . "; ";
+					}
+
 					// discount type is blank
 					if ( 0 == strlen( $edd_discount_type ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Discount type is blank.', 'edd') . "; ";
 					}
-					
-					// discount type is invaid
-					if ( ( $edd_discount_type != 'flat' ) && ( $edd_discount_type != 'percentage' ) ) {
+
+					// discount type is invalid
+					$discount_types = array( 'flat', 'percentage' );
+					if ( ! in_array( $edd_discount_type, $discount_types ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Discount type is invalid.', 'edd') . "; ";
 					}
-					
+
 					// discount code is blank
 					if ( 0 == strlen( $edd_discount_code ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Discount code is blank.', 'edd') . "; ";
 					}
-					
+
 					// start time validation
 					if ( ! strtotime( $edd_discount_start ) ) {
 						$validation_error = true;
 						$validation_msg  .= sprintf(__('Date validation failed for string: %s', 'edd'), $edd_discount_start) . "; ";
 					}
-					
+
 					// end time validation
 					if ( ! strtotime( $edd_discount_end ) ) {
 						$validation_error = true;
 						$validation_msg  .= sprintf(__('Date validation failed for string: %s', 'edd'), $edd_discount_end) . "; ";
 					}
-					
+
 					// set start time to correct date type
 					$edd_discount_start =  date( 'm/d/Y H:i:s', strtotime( $edd_discount_start ) );
-					
+
 					// set end time to the correct date type
 					$edd_discount_end =  date( 'm/d/Y H:i:s',  strtotime(  date( 'm/d/Y', strtotime( $edd_discount_end ) ) . ' 23:59:59' )  );
-				
-					// check status 
+
+					// check status
 					$status = array( 'active', 'inactive', 'expired' );
 					if ( ! in_array( $edd_discount_status, $status ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Status needs to be active, inactive, or pending', 'edd') . "; ";
 					}
-					
-					// maybe more validation later
 
+					// maybe more validation later
 
 					if ( $validation_error ) {
 						// report error and loop
@@ -195,85 +201,44 @@ function edd_import_coupon_csv_file() {
 							$edd_log_file .= sprintf(__('Successfully validated row: %d', 'edd'), $row_ctr ) . "\n";
 
 						} else {
-							
 
-							if( ! empty( $edd_discount_product_reqs ) ) {
-								$edd_discount_product_reqs = explode("|",$edd_discount_product_reqs);
-								foreach($edd_discount_product_reqs as $index => $val){
-									$edd_discount_product_reqs[$index] = trim($val);  
-								}
+							if ( ! empty( $edd_discount_product_reqs ) ) {
+								$edd_discount_product_reqs = wp_parse_id_list( explode( "|", $edd_discount_product_reqs ) );
 							} else {
 								$edd_discount_product_reqs = false;
 							}
-							$meta = array(
-									'code'       		=> $edd_discount_code,
-									'uses'       		=> $edd_discount_uses,
-									'max_uses'   		=> $edd_discount_max_uses,
-									'amount'     		=> $edd_discount_amount,
-									'start'      		=> $edd_discount_start,
-									'expiration' 		=> $edd_discount_end,
-									'type'       		=> $edd_discount_type,
-									'min_price'   		=> $edd_discount_min_price,
-									'product_reqs'      => $edd_discount_product_reqs,
-									'product_condition' => $edd_discount_product_condition,
-									'is_not_global'     => $edd_discount_is_not_global,
-									'is_single_use'     => $edd_discount_is_single_use
+
+							$args = array(
+								'name'              => sanitize_text_field( $edd_discount_name ),
+								'code'              => $edd_discount_code,
+								'status'            => $edd_discount_status,
+								'uses'              => absint( $edd_discount_uses ),
+								'max'               => absint( $edd_discount_max_uses ),
+								'amount'            => floatval( $edd_discount_amount ),
+								'start'             => $edd_discount_start,
+								'expiration'        => $edd_discount_end,
+								'type'              => $edd_discount_type,
+								'min_price'         => floatval( $edd_discount_min_price ),
+								'products'          => $edd_discount_product_reqs,
+								'product_condition' => $edd_discount_product_condition,
+								'not_global'        => boolval( $edd_discount_is_not_global ),
+								'use_once'          => boolval( $edd_discount_is_single_use ),
 							);
-						
+
 							// Is it already made?
-							if ( ( 0 == strlen( $edd_discount_id ) ) && edd_discount_exists( $edd_discount_id ) ){
-							
-								wp_update_post( array(
-									'ID'          => $edd_discount_id,
-									'post_title'  => $edd_discount_name,
-									'post_status' => $edd_discount_status
-								) );
+							$discount = edd_get_discount( $edd_discount_id );
 
-								foreach( $meta as $key => $value ) {
-									if ( is_string( $value ) || is_int( $value ) ){
-										update_post_meta( $edd_discount_id , '_edd_discount_' . $key, strip_tags( addslashes( $value ) ) );
-									}
-									elseif ( is_array( $value ) ){
-										update_post_meta( $edd_discount_id , '_edd_discount_' . $key, array_map( 'absint',  $value ) );										
-									}
-									else {
-										update_post_meta( $edd_discount_id , '_edd_discount_' . $key, $value );
-									}
-								}
+							if ( $discount ) {
+								// Update existing discount.
+								$discount_id = edd_store_discount( $args, $discount->id );
+
 								$edd_log_file .= sprintf(__('Successfully updated row: %d', 'edd'), $row_ctr ) . "\n";
-								
-							}
-							else {
-							
-								// add post
-								// setup post args
-								$new_download_args = array(
-									'post_type' 	 => 'edd_discount',
-									'post_title' 	 => $edd_discount_name,
-									'post_status' 	 => $edd_discount_status,
-								);
-								$new_download_id = wp_insert_post( $new_download_args , true );
-							
 
-								foreach ( $meta as $key => $value ) {
-									if ( is_string( $value ) || is_int( $value ) ){
-										update_post_meta( $new_download_id , '_edd_discount_' . $key, strip_tags( addslashes( $value ) ) );
-									}
-									elseif ( is_array( $value ) ){
-										update_post_meta( $new_download_id , '_edd_discount_' . $key, array_map( 'absint',  $value ) );										
-									}
-									else {
-										update_post_meta( $new_download_id , '_edd_discount_' . $key, $value );
-									}
-								}
+							} else {
+								// Add new discount.
+								$discount_id = edd_store_discount( $args );
+
 								$edd_log_file .= sprintf(__('Successfully imported row: %d', 'edd'), $row_ctr ) . "\n";
-							
-							}
-
-							if ( is_wp_error( $new_download_id ) ) {
-
-								$edd_log_file .= sprintf( __('Error importing row %d: ', 'edd'), $row_ctr) . $new_download_id->get_error_message() ;
-
 							}
 
 						} // if ( just validating )

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -184,7 +184,7 @@ function edd_import_coupon_csv_file() {
 
 					// check status
 					$status = array( 'active', 'inactive', 'expired' );
-					if ( ! in_array( $edd_discount_status, $status ) ) {
+					if ( ! in_array( $edd_discount_status, $status, true ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Status needs to be active, inactive, or pending', 'edd') . "; ";
 					}

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -151,8 +151,13 @@ function edd_import_coupon_csv_file() {
 						$validation_msg  .= __('Discount type is blank.', 'edd') . "; ";
 					}
 
+					// Keep backward compatibility.
+					if ( 'percentage' === $edd_discount_type ) {
+						$edd_discount_type = 'percent';
+					}
+
 					// discount type is invalid
-					$discount_types = array( 'flat', 'percentage' );
+					$discount_types = array( 'flat', 'percent' );
 					if ( ! in_array( $edd_discount_type, $discount_types, true ) ) {
 						$validation_error = true;
 						$validation_msg  .= __('Discount type is invalid.', 'edd') . "; ";

--- a/includes/import-functions.php
+++ b/includes/import-functions.php
@@ -138,7 +138,7 @@ function edd_import_coupon_csv_file() {
 						$validation_msg  .= __('Discount code is blank.', 'edd') . "; ";
 					}
 
-					// Verify only accepted characters.
+					// Verify that discount code only has accepted characters.
 					$sanitized_discount_code = preg_replace( '/[^a-zA-Z0-9-_]+/', '', $edd_discount_code );
 					if ( strtoupper( $edd_discount_code ) !== strtoupper( $sanitized_discount_code ) ) {
 						$validation_error = true;


### PR DESCRIPTION
Adding/updating discounts from CSV file was very broken and outdated. I switched to `edd_store_coupon()` function. Reason for this choice is to keep compatibility between EDD 3.0 & EDD 2.10. I didn't change arguments to the latest ones since they are not supported in both versions (`eed_store_coupon()` converts them to newer version). Those that I did change is because some arguments weren't working anymore since we don't create meta directly and instead rely on EDD API.

There are some open questions:

1. In example CSV file, values for some arguments are `0` or `1` (so `false` or `true`). That works for `not_global` and `use_once`. But it's not working for `product_condition` because it accepts only strings: `all` or `any`. ([In `EDD_CLI::create_discounts()`](https://github.com/easydigitaldownloads/easy-digital-downloads/blob/289400c2f83d792c6ea645ef9eb2962fae1455a1/includes/class-edd-cli.php#L777-L797), `0` and `1` are meant to be array indexes; should we use that functionality or switch to strings?)
2. In both EDD 3.0 & EDD 2.10, discount supports excluded downloads. But there is no support in coupon importer.

Also, I improved security when processing CSV file. In the past, there was no validation at all whether current user has any permission (even whether user is logged in or not!) or of nonces, so anyone could `POST` CSV file to any WordPress page/endpoint, just by knowing field names. I switched permission check from `manage_options` to `manage_shop_discounts`.